### PR TITLE
Fix typo in documentation of adjacency matrix

### DIFF
--- a/bridges/graph_adj_matrix.py
+++ b/bridges/graph_adj_matrix.py
@@ -54,7 +54,7 @@ class GraphAdjMatrix():
     #     exists. This method will replace the value for this key
     #
     #     @param k - vertex key value
-    #     @param 3 - user specified data, part of the vertex data
+    #     @param e - user specified data, part of the vertex data
     #
     #
     def add_vertex(self, k, e):


### PR DESCRIPTION
Should be an `e` instead of a `3`. Although `e` isn't really an acceptable parameter name either.